### PR TITLE
Jdaguilar patch 1

### DIFF
--- a/Get data from Google Docs.pq
+++ b/Get data from Google Docs.pq
@@ -1,6 +1,6 @@
 let Docs=
 
-(key as text)=>
+(#"GOOGLE SHEET URL" as text)=>
 let
     new_url = Text.Replace(#"GOOGLE SHEET URL", "edit?usp=sharing", "export?format=xlsx"),
     Source = Excel.Workbook(Web.Contents(new_url), null, true)

--- a/Get data from Google Docs.pq
+++ b/Get data from Google Docs.pq
@@ -2,7 +2,8 @@ let Docs=
 
 (key as text)=>
 let
-    Source = Excel.Workbook(Web.Contents("https://docs.google.com/spreadsheets/d/"&key&"/export?format=xlsx"), null, true)
+    new_url = Text.Replace(#"GOOGLE SHEET URL", "edit?usp=sharing", "export?format=xlsx"),
+    Source = Excel.Workbook(Web.Contents(new_url), null, true)
 in 
 Source,
 


### PR DESCRIPTION
Hi,

I propose to change `key` by `#"GOOGLE SHEET URL"` in order to change the name. Instead to use only `key`, we use all URL saved in `#"GOOGLE SHEET URL"`, and then replace `edit?usp=sharing` by `export?format=xlsx`
